### PR TITLE
Fix dash SOC display

### DIFF
--- a/Software/CANBRIDGE-2port/source/Src/can-bridge-firmware.c
+++ b/Software/CANBRIDGE-2port/source/Src/can-bridge-firmware.c
@@ -239,7 +239,7 @@ void can_handler(uint8_t can_bus, CAN_FRAME *frame)
 						if( My_Leaf == MY_LEAF_2014 ) 
 						{
 							//Calculate the SOC% value to send to the dash (Battery sends 10-95% which needs to be rescaled to dash 0-100%)
-							dash_soc = LB_MIN_SOC + (LB_MAX_SOC - LB_MIN_SOC) * (battery_soc_pptt - MINPERCENTAGE) / (MAXPERCENTAGE - MINPERCENTAGE); 
+							dash_soc = LB_MIN_SOC + (LB_MAX_SOC - LB_MIN_SOC) * (1.0 * battery_soc_pptt - MINPERCENTAGE) / (MAXPERCENTAGE - MINPERCENTAGE); 
 							if (dash_soc < 0)
 							{ //avoid underflow
 									dash_soc = 0;

--- a/Software/CANBRIDGE-3port/leaf-can-bridge-3-port/can-bridge-firmware.c
+++ b/Software/CANBRIDGE-3port/leaf-can-bridge-3-port/can-bridge-firmware.c
@@ -334,7 +334,7 @@ void can_handler(uint8_t can_bus){
 				if( My_Leaf == MY_LEAF_2014 )
 				{
 					//Calculate the SOC% value to send to the dash (Battery sends 10-95% which needs to be rescaled to dash 0-100%)
-					dash_soc = LB_MIN_SOC + (LB_MAX_SOC - LB_MIN_SOC) * (battery_soc_pptt - MINPERCENTAGE) / (MAXPERCENTAGE - MINPERCENTAGE);
+					dash_soc = LB_MIN_SOC + (LB_MAX_SOC - LB_MIN_SOC) * (1.0 * battery_soc_pptt - MINPERCENTAGE) / (MAXPERCENTAGE - MINPERCENTAGE);
 					if (dash_soc < 0)
 					{ //avoid underflow
 						dash_soc = 0;


### PR DESCRIPTION
When mapping from [5-95] to [0-100], force a double calculation to be done. Otherwise it might end up as 0% and show ---%.