### PR TITLE
Bugfix: ZE0 CAN sending improvements

### DIFF
--- a/Software/CANBRIDGE-2port/source/Src/can-bridge-firmware.c
+++ b/Software/CANBRIDGE-2port/source/Src/can-bridge-firmware.c
@@ -239,7 +239,7 @@ void can_handler(uint8_t can_bus, CAN_FRAME *frame)
 						if( My_Leaf == MY_LEAF_2014 ) 
 						{
 							//Calculate the SOC% value to send to the dash (Battery sends 10-95% which needs to be rescaled to dash 0-100%)
-							dash_soc = LB_MIN_SOC + (LB_MAX_SOC - LB_MIN_SOC) * (1.0 * battery_soc_pptt - MINPERCENTAGE) / (MAXPERCENTAGE - MINPERCENTAGE); 
+							dash_soc = (int16_t)(LB_MIN_SOC + (LB_MAX_SOC - LB_MIN_SOC) * (1.0 * battery_soc_pptt - MINPERCENTAGE) / (MAXPERCENTAGE - MINPERCENTAGE)); 
 							if (dash_soc < 0)
 							{ //avoid underflow
 									dash_soc = 0;

--- a/Software/CANBRIDGE-2port/source/Src/can-bridge-firmware.c
+++ b/Software/CANBRIDGE-2port/source/Src/can-bridge-firmware.c
@@ -91,6 +91,9 @@ volatile static uint8_t flip_3B8 = 0;
 
 static CAN_FRAME swap_605_message = {.ID = 0x605, .dlc = 1, .ide = 0, .rtr = 0, .data = {0}};
 static CAN_FRAME swap_607_message = {.ID = 0x607, .dlc = 1, .ide = 0, .rtr = 0, .data = {0}};
+static CAN_FRAME AZE0_45E_message	= {.ID = 0x45E, .dlc = 1, .ide = 0, .rtr = 0, .data = {0x00}};
+static CAN_FRAME AZE0_481_message	= {.ID =  0x481, .dlc = 2, .ide = 0, .rtr = 0, .data = {0x40,0x00}};
+
 
 static uint8_t	crctable[256] = {0,133,143,10,155,30,20,145,179,54,60,185,40,173,167,34,227,102,108,233,120,253,247,114,80,213,223,90,203,78,68,193,67,198,204,73,216,93,87,210,240,117,127,250,107,238,228,97,160,37,47,170,59,190,180,49,19,150,156,25,136,13,7,130,134,3,9,140,29,152,146,23,53,176,186,63,174,43,33,164,101,224,234,111,254,123,113,244,214,83,89,220,77,200,194,71,197,64,74,207,94,219,209,84,118,243,249,124,237,104,98,231,38,163,169,44,189,56,50,183,149,16,26,159,14,139,129,4,137,12,6,131,18,151,157,24,58,191,181,48,161,36,46,171,106,239,229,96,241,116,126,251,217,92,86,211,66,199,205,72,202,79,69,192,81,212,222,91,121,252,246,115,226,103,109,232,41,172,166,35,178,55,61,184,154,31,21,144,1,132,142,11,15,138,128,5,148,17,27,158,188,57,51,182,39,162,168,45,236,105,99,230,119,242,248,125,95,218,208,85,196,65,75,206,76,201,195,70,215,82,88,221,255,122,112,245,100,225,235,110,175,42,32,165,52,177,187,62,28,153,147,22,135,2,8,141};
 
@@ -190,6 +193,24 @@ void can_handler(uint8_t can_bus, CAN_FRAME *frame)
 						//this message is only sent by 62kWh packs. We use this info to autodetect battery size
 						My_Battery = MY_BATTERY_62KWH;
 						break;
+				case 0x5B9:
+            if( My_Leaf == MY_LEAF_2011 )
+            {
+							PushCan(battery_can_bus, CAN_TX, &AZE0_45E_message); // 500ms
+							PushCan(battery_can_bus, CAN_TX, &AZE0_481_message); // 500ms
+							
+							frame->dlc = 7;
+							if (charging_state == CHARGING_SLOW)
+							{
+									frame->data[5] = 0xFF;
+							}
+							else
+							{
+									frame->data[5] = 0x4A;
+							}
+							frame->data[6] = 0x80;
+            }
+						break;
 				case 0x5EB:
 						//This message is sent by 40/62kWh packs.
 						if (My_Battery == MY_BATTERY_62KWH)
@@ -258,6 +279,10 @@ void can_handler(uint8_t can_bus, CAN_FRAME *frame)
 					if(frame->dlc == 6)
 					{	//On ZE0 this message is 6 bytes long
 						My_Leaf = MY_LEAF_2011;
+						//We extend the message towards the battery
+						frame->dlc = 8;
+						frame->data[6] = 0x04;
+						frame->data[7] = 0x00;
 					}
 					else if(frame->dlc == 8)
 					{	//On AZE0 and ZE1, this message is 8 bytes long
@@ -271,7 +296,7 @@ void can_handler(uint8_t can_bus, CAN_FRAME *frame)
 					}
 					else
 					{
-						//message is originating from ZE0 OBC
+						//message is originating from ZE0 OBC (OR ZE1!)
 						My_Leaf = MY_LEAF_2011;
 					}
 				break;
@@ -282,6 +307,9 @@ void can_handler(uint8_t can_bus, CAN_FRAME *frame)
             if( My_Leaf == MY_LEAF_2011 )
             {
                 CANMASK = (frame->data[2] & 0x04) >> 2;
+								//Extend the message from 6->7 bytes
+							frame->dlc = 7;
+							frame->data[6] = 0x00;
             }
 
             break;


### PR DESCRIPTION
### What
This PR improves the CAN message handling towards an upgraded battery fitted onto a ZE0

### Why
To remove DTCs and make upgrades better

### How
Based on the excellent findings from @nzautomate in https://github.com/dalathegreat/Nissan-LEAF-Battery-Upgrade/issues/25

Attached .srec file for anyone wanting to test on 2-port!
[canbridge_4.21beta.zip](https://github.com/dalathegreat/Nissan-LEAF-Battery-Upgrade/files/15422406/canbridge_4.21beta.zip)
