### PR TITLE
Bugfix: Incorrect scaling of instrumentation cluster on ZE0

### DIFF
--- a/Software/CANBRIDGE-2port/source/Src/can-bridge-firmware.c
+++ b/Software/CANBRIDGE-2port/source/Src/can-bridge-firmware.c
@@ -253,17 +253,15 @@ void can_handler(uint8_t can_bus, CAN_FRAME *frame)
                 if (VCM_WakeUpSleepCommand == 3)
                 {                                                  // VCM command: wakeup
 										frame->data[3] = (frame->data[3] & 0xD7) | 0x28; // FRLYON=1, INTERLOCK=1
-                }
-								
-								if (startup_counter_1DB >= 100 && startup_counter_1DB <= 300) // Between 1s and 2s after poweron
-								{
-									frame->data[3] = (frame->data[3] | 0x10); // Set the full charge flag to ON during startup
-								}																						// This is to avoid instrumentation cluster scaling bars incorrectly
-								
-								if(startup_counter_1DB < 1000)
-								{
-									startup_counter_1DB++;
-								}
+                }			
+				if (startup_counter_1DB >= 100 && startup_counter_1DB <= 300) // Between 1s and 3s after poweron
+				{
+					frame->data[3] = (frame->data[3] | 0x10); // Set the full charge flag to ON during startup
+				}											// This is to avoid instrumentation cluster scaling bars incorrectly
+				if(startup_counter_1DB < 1000)
+				{
+					startup_counter_1DB++;
+				}
 								
 						}
 
@@ -427,28 +425,28 @@ void can_handler(uint8_t can_bus, CAN_FRAME *frame)
                     swap_5bc_remaining.LB_RCHGTCON = 0;
                 }
 								
-								if(startup_counter_1DB < 600) // During the first 5s of bootup, write GIDS to the max value for the pack
-								{
-									switch (My_Battery)
-                    {
-                    case MY_BATTERY_24KWH:
-											swap_5bc_remaining.LB_CAPR = 220;
-											swap_5bc_full.LB_CAPR = 220;
-											   break;
-										case MY_BATTERY_30KWH:
-											swap_5bc_remaining.LB_CAPR = 310;
-											swap_5bc_full.LB_CAPR = 310;
-											   break;
-                    case MY_BATTERY_40KWH:
-											swap_5bc_remaining.LB_CAPR = 420;
-											swap_5bc_full.LB_CAPR = 420;
-											   break;
-										case MY_BATTERY_62KWH:
-											swap_5bc_remaining.LB_CAPR = 630;
-											swap_5bc_full.LB_CAPR = 630;
-											   break;
-									}
-								}
+				if(startup_counter_1DB < 600) // During the first 6s of bootup, write GIDS to the max value for the pack
+				{
+				switch (My_Battery)
+					{
+					case MY_BATTERY_24KWH:
+							swap_5bc_remaining.LB_CAPR = 220;
+							swap_5bc_full.LB_CAPR = 220;
+							   break;
+						case MY_BATTERY_30KWH:
+							swap_5bc_remaining.LB_CAPR = 310;
+							swap_5bc_full.LB_CAPR = 310;
+							   break;
+					case MY_BATTERY_40KWH:
+							swap_5bc_remaining.LB_CAPR = 420;
+							swap_5bc_full.LB_CAPR = 420;
+							   break;
+						case MY_BATTERY_62KWH:
+							swap_5bc_remaining.LB_CAPR = 630;
+							swap_5bc_full.LB_CAPR = 630;
+							   break;
+					}
+				}
 
                 skip_5bc--;
                 
@@ -737,7 +735,7 @@ void can_handler(uint8_t can_bus, CAN_FRAME *frame)
 				case 0x68C:
         case 0x603:
             reset_state(); // Reset all states, vehicle is starting up
-						startup_counter_1DB = 0;
+			startup_counter_1DB = 0;
             PushCan(battery_can_bus, CAN_TX, &swap_605_message); // Send these ZE1 messages towards battery
             PushCan(battery_can_bus, CAN_TX, &swap_607_message);
         break;

--- a/Software/CANBRIDGE-2port/source/Src/can-bridge-firmware.c
+++ b/Software/CANBRIDGE-2port/source/Src/can-bridge-firmware.c
@@ -67,7 +67,7 @@ static volatile uint8_t skip_5bc = 1;             // for 2011 battery swap, skip
 static volatile uint8_t alternate_5bc = 0;        // for 2011 battery swap
 static volatile uint8_t seen_1da = 0;             // for 2011 battery swap
 static volatile uint8_t seconds_without_1f2 = 0;  // bugfix: 0x603/69C/etc. isn't sent upon charge start on the gen1 Leaf, so we need to trigger our reset on a simple absence of messages
-
+static volatile uint16_t startup_counter_1DB = 0;
 // bits															10					10					4				8				7			1				3	(2 space)		1					5						13
 static Leaf_2011_5BC_message swap_5bc_remaining = {.LB_CAPR = 0x12C, .LB_FULLCAP = 0x32, .LB_CAPSEG = 0, .LB_AVET = 50, .LB_SOH = 99, .LB_CAPSW = 0, .LB_RLIMIT = 0, .LB_CAPBALCOMP = 1, .LB_RCHGTCON = 0x09, .LB_RCHGTIM = 0};
 static Leaf_2011_5BC_message swap_5bc_full = {.LB_CAPR = 0x12C, .LB_FULLCAP = 0x32, .LB_CAPSEG = 12, .LB_AVET = 50, .LB_SOH = 99, .LB_CAPSW = 1, .LB_RLIMIT = 0, .LB_CAPBALCOMP = 1, .LB_RCHGTCON = 0x09, .LB_RCHGTIM = 0};
@@ -254,8 +254,18 @@ void can_handler(uint8_t can_bus, CAN_FRAME *frame)
                 {                                                  // VCM command: wakeup
 										frame->data[3] = (frame->data[3] & 0xD7) | 0x28; // FRLYON=1, INTERLOCK=1
                 }
-
-            }
+								
+								if (startup_counter_1DB >= 100 && startup_counter_1DB <= 200) // Between 1s and 2s after poweron
+								{
+									frame->data[3] = (frame->data[3] | 0x10); // Set the full charge flag to ON during startup
+								}																						// This is to avoid instrumentation cluster scaling bars incorrectly
+								
+								if(startup_counter_1DB < 1000)
+								{
+									startup_counter_1DB++;
+								}
+								
+						}
 
 						if( My_Leaf == MY_LEAF_2014 ) 
 						{
@@ -416,6 +426,25 @@ void can_handler(uint8_t can_bus, CAN_FRAME *frame)
                     swap_5bc_remaining.LB_RCHGTIM = 0;
                     swap_5bc_remaining.LB_RCHGTCON = 0;
                 }
+								
+								if(startup_counter_1DB < 500) // During the first 5s of bootup, write GIDS to the max value for the pack
+								{
+									switch (My_Battery)
+                    {
+                    case MY_BATTERY_24KWH:
+											swap_5bc_remaining.LB_CAPR = 220;
+											   break;
+										case MY_BATTERY_30KWH:
+											swap_5bc_remaining.LB_CAPR = 310;
+											   break;
+                    case MY_BATTERY_40KWH:
+											swap_5bc_remaining.LB_CAPR = 420;
+											   break;
+										case MY_BATTERY_62KWH:
+											swap_5bc_remaining.LB_CAPR = 630;
+											   break;
+									}
+								}
 
                 skip_5bc--;
                 
@@ -704,7 +733,7 @@ void can_handler(uint8_t can_bus, CAN_FRAME *frame)
 				case 0x68C:
         case 0x603:
             reset_state(); // Reset all states, vehicle is starting up
-
+						startup_counter_1DB = 0;
             PushCan(battery_can_bus, CAN_TX, &swap_605_message); // Send these ZE1 messages towards battery
             PushCan(battery_can_bus, CAN_TX, &swap_607_message);
         break;

--- a/Software/CANBRIDGE-2port/source/Src/can-bridge-firmware.c
+++ b/Software/CANBRIDGE-2port/source/Src/can-bridge-firmware.c
@@ -255,7 +255,7 @@ void can_handler(uint8_t can_bus, CAN_FRAME *frame)
 										frame->data[3] = (frame->data[3] & 0xD7) | 0x28; // FRLYON=1, INTERLOCK=1
                 }
 								
-								if (startup_counter_1DB >= 100 && startup_counter_1DB <= 200) // Between 1s and 2s after poweron
+								if (startup_counter_1DB >= 100 && startup_counter_1DB <= 300) // Between 1s and 2s after poweron
 								{
 									frame->data[3] = (frame->data[3] | 0x10); // Set the full charge flag to ON during startup
 								}																						// This is to avoid instrumentation cluster scaling bars incorrectly
@@ -427,21 +427,25 @@ void can_handler(uint8_t can_bus, CAN_FRAME *frame)
                     swap_5bc_remaining.LB_RCHGTCON = 0;
                 }
 								
-								if(startup_counter_1DB < 500) // During the first 5s of bootup, write GIDS to the max value for the pack
+								if(startup_counter_1DB < 600) // During the first 5s of bootup, write GIDS to the max value for the pack
 								{
 									switch (My_Battery)
                     {
                     case MY_BATTERY_24KWH:
 											swap_5bc_remaining.LB_CAPR = 220;
+											swap_5bc_full.LB_CAPR = 220;
 											   break;
 										case MY_BATTERY_30KWH:
 											swap_5bc_remaining.LB_CAPR = 310;
+											swap_5bc_full.LB_CAPR = 310;
 											   break;
                     case MY_BATTERY_40KWH:
 											swap_5bc_remaining.LB_CAPR = 420;
+											swap_5bc_full.LB_CAPR = 420;
 											   break;
 										case MY_BATTERY_62KWH:
 											swap_5bc_remaining.LB_CAPR = 630;
+											swap_5bc_full.LB_CAPR = 630;
 											   break;
 									}
 								}

--- a/Software/CANBRIDGE-3port/leaf-can-bridge-3-port/can-bridge-firmware.c
+++ b/Software/CANBRIDGE-3port/leaf-can-bridge-3-port/can-bridge-firmware.c
@@ -74,7 +74,7 @@ volatile	uint8_t		seen_1da				= 0; //for 2011 battery swap
 volatile	uint8_t		seconds_without_1f2		= 0; //bugfix: 0x603/69C/etc. isn't sent upon charge start on the gen1 Leaf, so we need to trigger our reset on a simple absence of messages
 volatile	uint8_t		main_battery_temp		= 0; 
 volatile	uint8_t		battery_can_bus			= 2; //keeps track on which CAN bus the battery talks. 
-
+volatile	uint16_t	startup_counter_1DB		= 0;
 //timer variables
 volatile	uint16_t	sec_timer			= 1;	//actually the same as ms_timer but counts down from 1000
 
@@ -348,7 +348,14 @@ void can_handler(uint8_t can_bus){
 					{                                                  // VCM command: wakeup
 						frame.data[3] = (frame.data[3] & 0xD7) | 0x28; // FRLYON=1, INTERLOCK=1
 					}
-
+					if (startup_counter_1DB >= 100 && startup_counter_1DB <= 300) // Between 1s and 3s after poweron
+					{
+						frame.data[3] = (frame.data[3] | 0x10); // Set the full charge flag to ON during startup
+					}											  // This is to avoid instrumentation cluster scaling bars incorrectly					
+					if(startup_counter_1DB < 1000)
+					{
+						startup_counter_1DB++;
+					}
 				}
 
 				if( My_Leaf == MY_LEAF_2014 )
@@ -522,6 +529,29 @@ void can_handler(uint8_t can_bus){
 					swap_5bc_full.LB_CAPR = 0x3FF;
 					swap_5bc_remaining.LB_RCHGTIM = 0;
 					swap_5bc_remaining.LB_RCHGTCON = 0;
+				}
+				
+				if(startup_counter_1DB < 600) // During the first 6s of bootup, write GIDS to the max value for the pack
+				{
+					switch (My_Battery)
+					{
+						case MY_BATTERY_24KWH:
+						swap_5bc_remaining.LB_CAPR = 220;
+						swap_5bc_full.LB_CAPR = 220;
+						break;
+						case MY_BATTERY_30KWH:
+						swap_5bc_remaining.LB_CAPR = 310;
+						swap_5bc_full.LB_CAPR = 310;
+						break;
+						case MY_BATTERY_40KWH:
+						swap_5bc_remaining.LB_CAPR = 420;
+						swap_5bc_full.LB_CAPR = 420;
+						break;
+						case MY_BATTERY_62KWH:
+						swap_5bc_remaining.LB_CAPR = 630;
+						swap_5bc_full.LB_CAPR = 630;
+						break;
+					}
 				}
 			
 				skip_5bc--;
@@ -752,7 +782,7 @@ void can_handler(uint8_t can_bus){
 				case 0x68C:
 				case 0x603:
 				reset_state(); // Reset all states, vehicle is starting up
-
+				startup_counter_1DB = 0;
 				send_can(battery_can_bus, swap_605_message); // Send these ZE1 messages towards battery
 				send_can(battery_can_bus, swap_607_message);
 				break;


### PR DESCRIPTION
### What
This PR fixes the cosmetic issue that occurs on battery upgraded ZE0s. 

### Why
On the ZE0, incase you stop charge at any other point than 100%, that point becomes the 12/12 bars. This becomes problematic, for example if you stop charging at 60% on a 62kWh battery, then the instrumentation cluster will be extremely misleading

### How
During startup we
- Set GIDS value to the maximum of the battery (for first 5 seconds)
- At the same time, between second 1-2, we toggle the full charge completed flag. This re-syncs the bars to this new fake point

Massive thanks to @nzautomate for these findings! 🙌 

Testers welcome, .srec file for 2-port CAN bridge included in this PR
[canbridge_4.22beta.zip](https://github.com/user-attachments/files/15570128/canbridge_4.22beta.zip)
[canbridge_4.22beta2.zip](https://github.com/user-attachments/files/15614060/canbridge_4.22beta2.zip) <- Improved timing

