### PR TITLE
Bugfix: ZE0, fix SOH% bars stuck at 12/12

### DIFF
--- a/Software/CANBRIDGE-2port/source/Src/can-bridge-firmware.c
+++ b/Software/CANBRIDGE-2port/source/Src/can-bridge-firmware.c
@@ -42,6 +42,9 @@ static const uint16_t charge_time[4][7] =  {
                                     };
 // Lookup table battery temperature,	offset -40C		0    1   2   3  4    5   6   7   8   9  10  11  12
 static const uint8_t temp_lut[13] = {25, 28, 31, 34, 37, 50, 63, 76, 80, 82, 85, 87, 90};
+//Lookup table for battery state of health
+static const uint8_t bars_lut[16]						= {0,1,2,3,4,4,5,6,7,8,8,9,10,11,12,12};
+static volatile	uint8_t	capacity_segments_aze0  = 0;
 
 // charging variables
 static volatile uint8_t charging_state = 0;
@@ -398,25 +401,20 @@ void can_handler(uint8_t can_bus, CAN_FRAME *frame)
             if( My_Leaf == MY_LEAF_2011 )
             {
                 temp = ((frame->data[4] & 0xFE) >> 1); // Collect SOH value
-                if (frame->data[0] != 0xFF)
+                if (frame->data[0] != 0xFF) // Only modify values when GIDS value is available, that means LBC has booted
                 {
-                    // Only modify values when GIDS value is available, that means LBC has booted
-                    if ((frame->data[5] & 0x10) == 0x00)
-                    {
-                        // If everything is normal (no output power limit reason)
-                        convert_array_to_5bc(&leaf_40kwh_5bc, (uint8_t *)&frame->data);
-                        swap_5bc_remaining.LB_CAPR = leaf_40kwh_5bc.LB_CAPR;
-                        swap_5bc_full.LB_CAPR = leaf_40kwh_5bc.LB_CAPR;
-                        swap_5bc_remaining.LB_SOH = temp;
-                        swap_5bc_full.LB_SOH = temp;
-                        main_battery_temp = frame->data[3] / 20;
-                        main_battery_temp = temp_lut[main_battery_temp] + 1;
-                    }
-                    else
-                    {
-                        // Output power limited
-                    }
-                }
+										convert_array_to_5bc(&leaf_40kwh_5bc, (uint8_t *)&frame->data);
+										swap_5bc_remaining.LB_CAPR = leaf_40kwh_5bc.LB_CAPR;
+										swap_5bc_full.LB_CAPR = leaf_40kwh_5bc.LB_CAPR;
+										swap_5bc_remaining.LB_SOH = temp;
+										swap_5bc_full.LB_SOH = temp;
+										main_battery_temp = frame->data[3] / 20;
+										main_battery_temp = temp_lut[main_battery_temp] + 1;
+										if(frame->data[4] & 0x01) {
+											capacity_segments_aze0 = ((frame->data[2] & 0xF0) >> 4); 
+										}
+										swap_5bc_full.LB_CAPSEG = bars_lut[capacity_segments_aze0];
+								} 
                 else
                 {		//We are booting up, set charge times to unavailable
                     swap_5bc_remaining.LB_CAPR = 0x3FF;

--- a/Software/CANBRIDGE-3port/leaf-can-bridge-3-port/can-bridge-firmware.c
+++ b/Software/CANBRIDGE-3port/leaf-can-bridge-3-port/can-bridge-firmware.c
@@ -44,7 +44,9 @@ uint8_t		tx3_buffer_end		= 0;
 
 //Lookup table battery temperature,	offset -40C		0    1   2   3  4    5   6   7   8   9  10  11  12
 uint8_t		temp_lut[13]						= {25, 28, 31, 34, 37, 50, 63, 76, 80, 82, 85, 87, 90};
-
+//Lookup table for battery state of health
+uint8_t		bars_lut[16]						= {0,1,2,3,4,4,5,6,7,8,8,9,10,11,12,12};
+volatile	uint8_t		capacity_segments_aze0  = 0;
 //charging variables
 volatile	uint8_t		charging_state			= 0;
 volatile	uint8_t		starting_up				= 0;
@@ -511,20 +513,20 @@ void can_handler(uint8_t can_bus){
 				{
 				temp2 = ((frame.data[4] & 0xFE) >> 1); //Collect SOH value
 				if(frame.data[0] != 0xFF){ //Only modify values when GIDS value is available, that means LBC has booted
-					if((frame.data[5] & 0x10) == 0x00){ //If everything is normal (no output power limit reason)
-						convert_array_to_5bc(&leaf_40kwh_5bc, (uint8_t *) &frame.data);
-						swap_5bc_remaining.LB_CAPR = leaf_40kwh_5bc.LB_CAPR;
-						swap_5bc_full.LB_CAPR = leaf_40kwh_5bc.LB_CAPR;
-						swap_5bc_remaining.LB_SOH = temp2;
-						swap_5bc_full.LB_SOH = temp2;
-						current_capacity_wh = swap_5bc_full.LB_CAPR * 80;
-						main_battery_temp = frame.data[3] / 20;					
-						main_battery_temp = temp_lut[main_battery_temp] + 1;
-						} else { //Output power limited
-
+					convert_array_to_5bc(&leaf_40kwh_5bc, (uint8_t *) &frame.data);
+					swap_5bc_remaining.LB_CAPR = leaf_40kwh_5bc.LB_CAPR;
+					swap_5bc_full.LB_CAPR = leaf_40kwh_5bc.LB_CAPR;
+					swap_5bc_remaining.LB_SOH = temp2;
+					swap_5bc_full.LB_SOH = temp2;
+					current_capacity_wh = swap_5bc_full.LB_CAPR * 80;
+					main_battery_temp = frame.data[3] / 20;
+					main_battery_temp = temp_lut[main_battery_temp] + 1;
+					if(frame.data[4] & 0x01) {
+						capacity_segments_aze0 = ((frame.data[2] & 0xF0) >> 4); 
 					}
-				
-					} else {
+						swap_5bc_full.LB_CAPSEG = bars_lut[capacity_segments_aze0];
+					} 
+				else { //We are booting up, set charge times to unavailable
 					swap_5bc_remaining.LB_CAPR = 0x3FF;
 					swap_5bc_full.LB_CAPR = 0x3FF;
 					swap_5bc_remaining.LB_RCHGTIM = 0;
@@ -532,7 +534,7 @@ void can_handler(uint8_t can_bus){
 				}
 				
 				if(startup_counter_1DB < 600) // During the first 6s of bootup, write GIDS to the max value for the pack
-				{
+				{							  // This is to allow the instrument cluster to know how to scale the SOC bars
 					switch (My_Battery)
 					{
 						case MY_BATTERY_24KWH:


### PR DESCRIPTION
### What
This PR fixes a bug reported in #9 , that caused ZE0 vehicles to be stuck at 12/12 SOH bars, even though it should be lower
![bild](https://github.com/dalathegreat/Nissan-LEAF-Battery-Upgrade/assets/26695010/4cc36022-d8cb-463b-805c-29ad31e0cbad)

Thanks to @nzautomate for the findings!

Testers welcome, please find attached binaries for 2-port and 3-port
3-port: [can-bridge-firmware_v4.23beta.zip](https://github.com/user-attachments/files/15644637/can-bridge-firmware_v4.23beta.zip)
2-port: [canbridge_4.23beta.zip](https://github.com/user-attachments/files/15644723/canbridge_4.23beta.zip)
