### PR TITLE
Fix occasional can tx corruption in 2-port version

### DIFF
--- a/Software/CANBRIDGE-2port/source/Src/can.c
+++ b/Software/CANBRIDGE-2port/source/Src/can.c
@@ -428,8 +428,6 @@ CQ_STATUS PushCan( uint8_t canNum, uint8_t TxRx, CAN_FRAME *frame )
         canHead[ TxRx ][ canNum ] = ( canHead[ TxRx ][ canNum ] + 1 ) % CAN_QUEUE;        
         retVal = CQ_OK;
     }
-    
-    sendCan( canNum );
    
     return retVal;
 }


### PR DESCRIPTION
I was seeing these symptoms on a ZE0 with 40kWh once every 1 - 10 mins or so:
 - car shifts its self from ECO into D
 - cruise control disengages
 - OVMS stats momentarily glitch with corrupt values

Cause:
Race condition where PopCan() in main loop was also called from ISR on same buffer via PushCan()->sendCan(), which clobbered the buffer and caused occasional corrupt tx packets to be sent.

Fix:
Offending call removed, main loop seems to have no trouble keeping up on its own.

Tested ~1 month so far, all symptoms resolved.
Note: I compiled in STM32Cube IDE.

Thank you for sharing this beautiful project. I like many others am grateful for this making the upgrade viable.